### PR TITLE
added virtual destructor to Node class

### DIFF
--- a/src/Model.hpp
+++ b/src/Model.hpp
@@ -27,6 +27,7 @@ class Node
 {
 public:
     Node(Model& model, std::string name);
+    virtual ~Node(){};
 
     // Initialize the parameters of the node with a provided random number
     // engine.


### PR DESCRIPTION
Fixing crash on Apple clang version 14.0.0 (clang-1400.0.29.202) 

```
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/usr/include/c++/v1/__memory/unique_ptr.h:57:5: warning: delete called on 'Node' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
    delete __ptr;

      ^
```
